### PR TITLE
Remove composer repository url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,6 @@
   "description": "Ad Integration", 
   "license": "GPL-2.0+",
   "minimum-stability": "dev",
-  "repositories": [
-    {
-      "type": "composer",
-      "url": "https://packagist.drupal-composer.org"
-    }
-  ],
   "require": {
     "drupal/breakpoint_js_settings": "1.0-rc1"
   },


### PR DESCRIPTION
- Composer repository url is a root only setting
- The new version constraint of drupal/breakpoint_js_settings does not follow the version scheme from packagist.drupal-composer.org
