### PR TITLE
Check for correct canonical routes in adintegration lookup

### DIFF
--- a/src/AdIntegrationLookup.php
+++ b/src/AdIntegrationLookup.php
@@ -74,7 +74,7 @@ class AdIntegrationLookup implements AdIntegrationLookupInterface {
     $entity = NULL;
     // We only show ads on canonical routes - check for correct route.
     if (!in_array($routeMatch->getRouteName(), ['entity.node.canonical', 'entity.taxonomy_term.canonical'])) {
-      return;
+      return NULL;
     }
     foreach (static::SUPPORTED_ENTITY_PARAMETERS as $parameter) {
       if ($entity = $routeMatch->getParameter($parameter)) {

--- a/src/AdIntegrationLookup.php
+++ b/src/AdIntegrationLookup.php
@@ -72,22 +72,21 @@ class AdIntegrationLookup implements AdIntegrationLookupInterface {
    */
   public function byRoute($name, RouteMatchInterface $routeMatch, $termsOnly = FALSE) {
     $entity = NULL;
-    // We only show ads on canonical urls - check for correct route.
+    // We only show ads on canonical urls - check for correct routes.
+    // Otherwise we just return default settings.
     if (!in_array($routeMatch->getRouteName(), ['entity.node.canonical', 'entity.taxonomy_term.canonical'])) {
-      return;
-    }
-    foreach (static::SUPPORTED_ENTITY_PARAMETERS as $parameter) {
-      if ($entity = $routeMatch->getParameter($parameter)) {
-        if (is_numeric($entity)) {
-          $entity = Node::load($entity);
-        }
-        $setting = $this->searchEntity($name, $entity, $termsOnly);
-        if ($setting !== NULL) {
-          return $setting;
+      foreach (static::SUPPORTED_ENTITY_PARAMETERS as $parameter) {
+        if ($entity = $routeMatch->getParameter($parameter)) {
+          if (is_numeric($entity)) {
+            $entity = Node::load($entity);
+          }
+          $setting = $this->searchEntity($name, $entity, $termsOnly);
+          if ($setting !== NULL) {
+            return $setting;
+          }
         }
       }
     }
-
     return $this->defaults($name);
   }
 

--- a/src/AdIntegrationLookup.php
+++ b/src/AdIntegrationLookup.php
@@ -72,7 +72,10 @@ class AdIntegrationLookup implements AdIntegrationLookupInterface {
    */
   public function byRoute($name, RouteMatchInterface $routeMatch, $termsOnly = FALSE) {
     $entity = NULL;
-
+    // We only show ads on canonical urls - check for correct route.
+    if (!in_array($routeMatch->getRouteName(), ['entity.node.canonical', 'entity.taxonomy_term.canonical'])) {
+      return;
+    }
     foreach (static::SUPPORTED_ENTITY_PARAMETERS as $parameter) {
       if ($entity = $routeMatch->getParameter($parameter)) {
         if (is_numeric($entity)) {

--- a/src/AdIntegrationLookup.php
+++ b/src/AdIntegrationLookup.php
@@ -72,7 +72,7 @@ class AdIntegrationLookup implements AdIntegrationLookupInterface {
    */
   public function byRoute($name, RouteMatchInterface $routeMatch, $termsOnly = FALSE) {
     $entity = NULL;
-    // We only show ads on canonical urls - check for correct route.
+    // We only show ads on canonical routes - check for correct route.
     if (!in_array($routeMatch->getRouteName(), ['entity.node.canonical', 'entity.taxonomy_term.canonical'])) {
       return;
     }


### PR DESCRIPTION
While defining custom routes we get fatal errors by the ad_integration module, cause the byRoute function does not check for canonical url to lookup ads. 

This PR will fix the issue by checking for node.canonical and taxonomy_term.canonical routes