### PR TITLE
fix php error on custom routes, cause entity objects are not available

### DIFF
--- a/src/AdIntegrationLookup.php
+++ b/src/AdIntegrationLookup.php
@@ -72,19 +72,21 @@ class AdIntegrationLookup implements AdIntegrationLookupInterface {
    */
   public function byRoute($name, RouteMatchInterface $routeMatch, $termsOnly = FALSE) {
     $entity = NULL;
-
-    foreach (static::SUPPORTED_ENTITY_PARAMETERS as $parameter) {
-      if ($entity = $routeMatch->getParameter($parameter)) {
-        if (is_numeric($entity)) {
-          $entity = Node::load($entity);
-        }
-        $setting = $this->searchEntity($name, $entity, $termsOnly);
-        if ($setting !== NULL) {
-          return $setting;
+    // We only show ads on canonical urls - check for correct routes.
+    // Otherwise we just return default settings.
+    if (!in_array($routeMatch->getRouteName(), ['entity.node.canonical', 'entity.taxonomy_term.canonical'])) {
+      foreach (static::SUPPORTED_ENTITY_PARAMETERS as $parameter) {
+        if ($entity = $routeMatch->getParameter($parameter)) {
+          if (is_numeric($entity)) {
+            $entity = Node::load($entity);
+          }
+          $setting = $this->searchEntity($name, $entity, $termsOnly);
+          if ($setting !== NULL) {
+            return $setting;
+          }
         }
       }
     }
-
     return $this->defaults($name);
   }
 

--- a/src/AdIntegrationLookup.php
+++ b/src/AdIntegrationLookup.php
@@ -74,7 +74,7 @@ class AdIntegrationLookup implements AdIntegrationLookupInterface {
     $entity = NULL;
     // We only show ads on canonical urls - check for correct routes.
     // Otherwise we just return default settings.
-    if (!in_array($routeMatch->getRouteName(), ['entity.node.canonical', 'entity.taxonomy_term.canonical'])) {
+    if (in_array($routeMatch->getRouteName(), ['entity.node.canonical', 'entity.taxonomy_term.canonical'])) {
       foreach (static::SUPPORTED_ENTITY_PARAMETERS as $parameter) {
         if ($entity = $routeMatch->getParameter($parameter)) {
           if (is_numeric($entity)) {

--- a/tests/src/Kernel/AdIntegrationTest.php
+++ b/tests/src/Kernel/AdIntegrationTest.php
@@ -216,7 +216,7 @@ class AdIntegrationTest extends KernelTestBase {
     /** @var PHPUnit_Framework_MockObject_MockObject $routeMatchMock */
     $routeMatchMock = $this->getMockBuilder('\Drupal\Core\Routing\CurrentRouteMatch')
       ->disableOriginalConstructor()
-      ->setMethods(['getParameter'])
+      ->setMethods(['getParameter', 'getRouteName'])
       ->getMock();
     $routeMatchMock->expects($this->any())
       ->method('getParameter')
@@ -224,6 +224,9 @@ class AdIntegrationTest extends KernelTestBase {
       ->will($this->returnValueMap(array(
         array('node', $node->id()),
       )));
+    $routeMatchMock->expects($this->any())
+      ->method('getRouteName')
+      ->willReturn('entity.node.canonical');
     $configFactory = \Drupal::service('config.factory');
     $entityTypeManager = \Drupal::service('entity_type.manager');
     /** @var AdIntegrationLookupInterface $adIntegrationLookup */


### PR DESCRIPTION

While defining custom routes we get fatal errors by the ad_integration module, cause the byRoute function does not check for canonical url to lookup ads.

This PR will fix the issue by checking for node.canonical and taxonomy_term.canonical routes