### PR TITLE
Add maxlength to keywords form fields

### DIFF
--- a/src/Plugin/Field/FieldWidget/AdSettingsWidget.php
+++ b/src/Plugin/Field/FieldWidget/AdSettingsWidget.php
@@ -113,6 +113,7 @@ class AdSettingsWidget extends WidgetBase implements ContainerFactoryPluginInter
     $element[$value_element_name]['#description'] = t('Comma separated ad keywords');
     $element[$value_element_name]['#default_value'] = isset($items[$delta]->$value_element_name) ? $items[$delta]->$value_element_name : NULL;
     $element[$value_element_name]['#required'] = FALSE;
+    $element[$value_element_name]['#maxlength'] = 256;
 
     return $element;
   }


### PR DESCRIPTION
Keywords in ad-integration can store up to 256 characters. The default maxlength of this field is set to 128 characters. This commit adds a maxlength attribute to the form field.

Make sure these boxes are checked before submitting your pull request - thank you!

- [x ] All coding styles are fulfilled. ([How to check for cs issues?](https://github.com/BurdaMagazinOrg/thunder-dev-tools/blob/master/README.md#code-style-guidelines))
- [x] All tests are running locally. ([How to run the test?](https://github.com/BurdaMagazinOrg/thunder-distribution/blob/8.x-1.x/docs/development.md#how-to-run-the-tests))
- [ ] Necessary update hooks are provided.
- [x] User roles have correct access for new introduced permission.
- [x] Every thunder module has a README.md in its root. Follow [this guidelines](https://www.drupal.org/node/2181737), but we don't need every topic.
- [x] Code is covered with well-balanced amount of inline comments.

If you are really awesome, then your feature is covered by additional tests. Well done!
